### PR TITLE
refactor: update SQL query to select display_name instead of name in account retrieval

### DIFF
--- a/backend/sql/getAccountNames.sql
+++ b/backend/sql/getAccountNames.sql
@@ -1,1 +1,1 @@
-SELECT name FROM Account;
+SELECT display_name FROM Account;

--- a/backend/src/controllers/accountController.ts
+++ b/backend/src/controllers/accountController.ts
@@ -6,8 +6,8 @@ const router = Router();
 
 router.get('/', async (_req: Request, res: Response) => {
   const getAccountNamesSQL = await loadSQL('getAccountNames.sql');
-  const { rows } = await client.query<{ name: string }>(getAccountNamesSQL);
-  res.json(rows.map((r: { name: string; }) => r.name));
+  const { rows } = await client.query<{ display_name: string }>(getAccountNamesSQL);
+  res.json(rows.map((r: { display_name: string; }) => r.display_name));
 });
 
 export default router;


### PR DESCRIPTION
We changed User to Account and the field name became display_name in #33 but we didn't update the getAccountNames query and the account controller.