### PR TITLE
fix: remove unnecessary page reload on logout in SettingsPage

### DIFF
--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -27,7 +27,6 @@ function RecipePage() {
     try {
       document.cookie = "authToken=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT";
       navigate("/");
-      window.location.reload();
     } catch(e) {
       alert(e);
     }


### PR DESCRIPTION
I'm not totally sure why this fixes the logout problem. Regardless, the window reload is redundant and unnecessary because of the navigation change.